### PR TITLE
Fix DHIS enrollments orgunits bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "close-patient-script",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "main": "src/index.ts",
     "description": "Generic script to close patients from the specified DHIS2 tracker program",
     "scripts": {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/3ec3qa5

### :memo: Implementation

DHIS new tracker api `trackedEntities.enrollments` doesn't reflect the correct orgUnits; but the events within does. This fix maps the enrollments with the orgUnit id and orgUnitName from its events. Also when filtering if the enrollments are completed or not, now we filter by program Id so it should be only one enrollment-program.