### PR TITLE
Add stats report on export, output enrollments without closure

### DIFF
--- a/src/data/ReportExportCsvRepository.ts
+++ b/src/data/ReportExportCsvRepository.ts
@@ -1,30 +1,70 @@
-import _ from "lodash";
 import * as CsvWriter from "csv-writer";
-import { ReportExportRepository, ReportExportSaveOptions } from "domain/repositories/ReportExportRepository";
+import _ from "lodash";
 import { Async } from "domain/entities/Async";
+import {
+    ReportExportRepository,
+    ReportExportSaveOptions,
+    ReportExportSaveStatsOptions,
+} from "domain/repositories/ReportExportRepository";
 
 export class ReportExportCsvRepository implements ReportExportRepository {
     async save(options: ReportExportSaveOptions): Async<void> {
-        const { entities, outputPath: reportPath, programId } = options;
+        const { entities, conflictEntities, outputPath: reportPath, programId } = options;
         const createCsvWriter = CsvWriter.createObjectCsvWriter;
         const csvHeader = _.map(headers, (obj, key) => ({ id: key, ...obj }));
         const csvWriter = createCsvWriter({ path: reportPath, header: csvHeader });
+
         const records = entities.map((entity): Row => {
             return {
                 programId: programId,
                 trackedEntityId: entity.trackedEntity,
                 orgUnitId: entity.orgUnit,
+                status: "READY",
             };
         });
-        await csvWriter.writeRecords(records);
+
+        const conflictRecords = conflictEntities.map((entity): Row => {
+            return {
+                programId: programId,
+                trackedEntityId: entity.trackedEntity,
+                orgUnitId: entity.orgUnit,
+                status: "CONFLICT",
+            };
+        });
+
+        await csvWriter.writeRecords([...records, ...conflictRecords]);
+    }
+
+    async saveStats(options: ReportExportSaveStatsOptions): Async<void> {
+        const { outputPath: reportPath, stats } = options;
+        const createCsvWriter = CsvWriter.createObjectCsvWriter;
+        const csvHeader = _.map(statsHeaders, (obj, key) => ({ id: key, ...obj }));
+        const statsRecord = [stats].map((stats): StatsRow => _.mapValues(stats, v => "" + v));
+        const csvWriter = createCsvWriter({
+            path: `${reportPath.split(".csv")[0]}-stats.csv`,
+            header: csvHeader,
+        });
+
+        await csvWriter.writeRecords(statsRecord);
     }
 }
 
-type Attr = "programId" | "trackedEntityId" | "orgUnitId";
+type Attr = "programId" | "trackedEntityId" | "orgUnitId" | "status";
+type StatsAttr = "created" | "updated" | "deleted" | "ignored" | "total";
 type Row = Record<Attr, string>;
+type StatsRow = Record<StatsAttr, string>;
 
 const headers: Record<Attr, { title: string }> = {
     programId: { title: "Program ID" },
     trackedEntityId: { title: "Tracked Entity ID" },
     orgUnitId: { title: "Org Unit ID" },
+    status: { title: "Status" },
+};
+
+const statsHeaders: Record<StatsAttr, { title: string }> = {
+    created: { title: "Created" },
+    updated: { title: "Updated" },
+    deleted: { title: "Deleted" },
+    ignored: { title: "Ignored" },
+    total: { title: "Total" },
 };

--- a/src/data/TrackerD2Repository.ts
+++ b/src/data/TrackerD2Repository.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import { TrackedEntityInstance as TrackedEntityInstanceD2Api } from "@eyeseetea/d2-api/api/trackedEntityInstances";
-import { GetOptions, ClosurePayload, TrackerRepository, Stats } from "domain/repositories/TrackerRepository";
+import { GetOptions, ClosurePayload, TrackerRepository } from "domain/repositories/TrackerRepository";
 import { D2Api } from "types/d2-api";
 import { Async } from "domain/entities/Async";
 import { TrackedEntity } from "domain/entities/TrackedEntity";
@@ -59,7 +59,7 @@ export class TrackerD2Repository implements TrackerRepository {
             });
     }
 
-    async save(payload: ClosurePayload): Async<Stats> {
+    async save(payload: ClosurePayload): Async<BundleReport> {
         return this.api
             .post<ApiSaveResponse & { message?: string }>(
                 "/tracker",
@@ -68,7 +68,7 @@ export class TrackerD2Repository implements TrackerRepository {
             )
             .getData()
             .then(res => {
-                if (res.status === "OK") return res.stats;
+                if (res.status === "OK") return res.bundleReport;
                 else throw new Error(getErrorMsg(res));
             })
             .catch(err => {
@@ -137,13 +137,62 @@ interface ApiGetResponse {
 }
 
 interface ApiSaveResponse {
-    validationReport?: { errorReports?: Report[] };
-    status: "OK" | "ERROR" | "WARNING";
+    bundleReport: BundleReport;
+    validationReport?: {
+        errorReports?: ErrorReport<"ENROLLMENT" | "EVENT" | "RELATIONSHIP" | "TRACKED_ENTITY">[];
+    };
+    timingStats: {
+        timers: {
+            commit: string;
+            preheat: string;
+            preprocess: string;
+            programrule: string;
+            programruleValidation: string;
+            totalImport: string;
+            validation: string;
+        };
+    };
+    status: Status;
     stats: Stats;
 }
 
-interface Report {
+export interface Stats {
+    created: number;
+    updated: number;
+    deleted: number;
+    ignored: number;
+    total: number;
+}
+
+export interface BundleReport {
+    stats: Stats;
+    status: Status;
+    typeReportMap: {
+        ENROLLMENT: TypeReport<"ENROLLMENT">;
+        EVENT: TypeReport<"EVENT">;
+        RELATIONSHIP: TypeReport<"RELATIONSHIP">;
+        TRACKED_ENTITY: TypeReport<"TRACKED_ENTITY">;
+    };
+}
+
+interface TypeReport<K> {
+    objectReports: ObjectReport<K>[];
+    stats: Stats;
+    trackerType: K;
+}
+
+interface ObjectReport<K> {
+    errorReports: ErrorReport<K>[];
+    index: number;
+    trackerType: K;
+    uid: Id;
+}
+
+interface ErrorReport<K> {
     message: string;
+    errorCode: string;
+    trackerType: K;
+    uid: Id;
 }
 
 interface TeiError {
@@ -151,4 +200,5 @@ interface TeiError {
     err: any;
 }
 
+type Status = "OK" | "ERROR" | "WARNING";
 type TrackedEntityInstance = Pick<TrackedEntityInstanceD2Api, "enrollments" | "trackedEntityInstance">;

--- a/src/data/TrackerD2Repository.ts
+++ b/src/data/TrackerD2Repository.ts
@@ -61,7 +61,11 @@ export class TrackerD2Repository implements TrackerRepository {
 
     async save(payload: ClosurePayload): Async<Stats> {
         return this.api
-            .post<ApiSaveResponse & { message?: string }>("/tracker", { async: false }, payload)
+            .post<ApiSaveResponse & { message?: string }>(
+                "/tracker",
+                { async: false, reportMode: "FULL" },
+                payload
+            )
             .getData()
             .then(res => {
                 if (res.status === "OK") return res.stats;

--- a/src/domain/repositories/ReportExportRepository.ts
+++ b/src/domain/repositories/ReportExportRepository.ts
@@ -1,6 +1,6 @@
+import { BundleReport } from "data/TrackerD2Repository";
 import { Async } from "domain/entities/Async";
 import { TrackedEntity } from "domain/entities/TrackedEntity";
-import { Stats } from "./TrackerRepository";
 
 export interface ReportExportRepository {
     save(options: ReportExportSaveOptions): Async<void>;
@@ -16,5 +16,5 @@ export interface ReportExportSaveOptions {
 
 export interface ReportExportSaveStatsOptions {
     outputPath: string;
-    stats: Stats;
+    bundleReport: BundleReport;
 }

--- a/src/domain/repositories/ReportExportRepository.ts
+++ b/src/domain/repositories/ReportExportRepository.ts
@@ -1,12 +1,20 @@
 import { Async } from "domain/entities/Async";
 import { TrackedEntity } from "domain/entities/TrackedEntity";
+import { Stats } from "./TrackerRepository";
 
 export interface ReportExportRepository {
     save(options: ReportExportSaveOptions): Async<void>;
+    saveStats(options: ReportExportSaveStatsOptions): Async<void>;
 }
 
 export interface ReportExportSaveOptions {
     outputPath: string;
     entities: TrackedEntity[];
+    conflictEntities: TrackedEntity[];
     programId: string;
+}
+
+export interface ReportExportSaveStatsOptions {
+    outputPath: string;
+    stats: Stats;
 }

--- a/src/domain/repositories/TrackerRepository.ts
+++ b/src/domain/repositories/TrackerRepository.ts
@@ -1,9 +1,10 @@
+import { BundleReport } from "data/TrackerD2Repository";
 import { Async } from "domain/entities/Async";
 import { Enrollment, Event, TrackedEntity } from "domain/entities/TrackedEntity";
 
 export interface TrackerRepository {
     get(options: GetOptions): Async<TrackedEntity[]>;
-    save(payload: ClosurePayload): Async<Stats>;
+    save(payload: ClosurePayload): Async<BundleReport>;
 }
 
 export interface GetOptions {
@@ -16,12 +17,4 @@ export interface GetOptions {
 export interface ClosurePayload {
     enrollments: Enrollment[];
     events: Event[];
-}
-
-export interface Stats {
-    created: number;
-    updated: number;
-    deleted: number;
-    ignored: number;
-    total: number;
 }

--- a/src/domain/usecases/ClosePatientsUseCase.ts
+++ b/src/domain/usecases/ClosePatientsUseCase.ts
@@ -28,49 +28,63 @@ export class ClosePatientsUseCase {
             post,
         } = options;
 
-        const payload = await this.programsRepository
+        const response = await this.programsRepository
             .get({ programId, orgUnitsIds, startDate, endDate })
-            .then(trackedEntities => {
-                return this.filterEntities(
+            .then(trackedEntities =>
+                this.filterEntities(
                     trackedEntities,
                     programId,
                     closureProgramId,
                     programStagesIds,
                     timeOfReference,
                     orgUnitsIds
-                );
-            })
-            .then(entities =>
-                _.isEmpty(entities)
-                    ? entities // (never[])
+                )
+            )
+            .then(({ filteredEntities, filteredEntitiesWithEnrollmentCompleted }) =>
+                _.isEmpty(filteredEntities)
+                    ? { filteredEntities, filteredEntitiesWithEnrollmentCompleted } // (never[])
                     : this.reportExportRepository
                           .save({
                               outputPath: saveReportPath,
-                              entities,
+                              entities: filteredEntities,
+                              conflictEntities: filteredEntitiesWithEnrollmentCompleted,
                               programId,
                           })
                           .then(() => {
                               log.info(`Report: ${options.saveReportPath}`);
-                              return entities;
+                              return { filteredEntities, filteredEntitiesWithEnrollmentCompleted };
                           })
             )
-            .then(entities =>
-                this.mapPayload(entities, {
+            .then(({ filteredEntities, filteredEntitiesWithEnrollmentCompleted }) => ({
+                payload: this.mapPayload(filteredEntities, {
                     programStagesIds,
                     timeOfReference,
                     pairsDeValue,
                     closureProgramId,
                     comments,
-                })
-            );
+                }),
+                filteredEntitiesWithEnrollmentCompleted,
+            }));
 
         if (post) {
-            this.programsRepository
-                .save(payload)
-                .then(stats =>
-                    log.info(`Closed patients. Enrollments and closure events: ${JSON.stringify(stats)}`)
-                );
-        } else log.info(`Payload: ${JSON.stringify(payload)}`);
+            this.programsRepository.save(response.payload).then(stats => {
+                if (!_.isEmpty(response.filteredEntitiesWithEnrollmentCompleted))
+                    log.info(
+                        `Tracked entities with enrollments completed without closure: ${response.filteredEntitiesWithEnrollmentCompleted
+                            .map(tei => tei.trackedEntity)
+                            .join(", ")}. Count: ${response.filteredEntitiesWithEnrollmentCompleted.length}`
+                    );
+                log.info(`Closed patients. Enrollments and closure events: ${JSON.stringify(stats)}`);
+                this.reportExportRepository
+                    .saveStats({
+                        outputPath: saveReportPath,
+                        stats,
+                    })
+                    .then(() => {
+                        log.info(`Stats report: ${options.saveReportPath}-stats.csv`);
+                    });
+            });
+        } else log.info(`Payload: ${JSON.stringify(response.payload)}`);
     }
 
     /* Private */
@@ -82,19 +96,55 @@ export class ClosePatientsUseCase {
         programStagesIds: string[],
         timeOfReference: number,
         orgUnitsIds?: string[]
-    ): TrackedEntity[] {
+    ): { filteredEntities: TrackedEntity[]; filteredEntitiesWithEnrollmentCompleted: TrackedEntity[] } {
+        const entitiesWithoutClosureButEnrollmentCompleted =
+            this.getEntitiesWithoutClosureButWithEnrollmentCompleted(
+                trackedEntities,
+                programId,
+                closureProgramId,
+                orgUnitsIds
+            );
         const entitiesWithoutClosure = this.getEntitiesWithoutClosure(
             trackedEntities,
             programId,
             closureProgramId,
             orgUnitsIds
         );
-        const filteredEntities = entitiesWithoutClosure.filter(entity => {
-            const dates = this.getDatesByProgramStages(entity, programStagesIds);
-            const occurredBefore = this.getRelativeDate(-timeOfReference).getTime();
-            return dates && !_.isEmpty(dates) && Math.max(...dates, occurredBefore) === occurredBefore;
+        const [filteredEntities = [], filteredEntitiesWithEnrollmentCompleted = []] = [
+            entitiesWithoutClosure,
+            entitiesWithoutClosureButEnrollmentCompleted,
+        ].map(teisArr =>
+            teisArr.filter(entity => {
+                const dates = this.getDatesByProgramStages(entity, programStagesIds);
+                const occurredBefore = this.getRelativeDate(-timeOfReference).getTime();
+                return dates && !_.isEmpty(dates) && Math.max(...dates, occurredBefore) === occurredBefore;
+            })
+        );
+
+        return { filteredEntities, filteredEntitiesWithEnrollmentCompleted };
+    }
+
+    private getEntitiesWithoutClosureButWithEnrollmentCompleted(
+        instances: TrackedEntity[],
+        programId: string,
+        closureProgramId: string,
+        orgUnitsIds?: string[]
+    ): TrackedEntity[] {
+        return instances.flatMap(entity => {
+            const enrollments = entity.enrollments.filter(({ orgUnit }) => orgUnitsIds?.includes(orgUnit));
+
+            const enrollmentFromProgram = enrollments.find(enrollment => enrollment.program === programId);
+            if (
+                //if enrollment exist, if enrollment IS COMPLETED, if there is not event with programStage (closureId) (deleted ones not count)
+                enrollmentFromProgram &&
+                enrollmentFromProgram.status === "COMPLETED" &&
+                !enrollmentFromProgram.events?.some(
+                    event => event.programStage === closureProgramId && !event.deleted
+                )
+            )
+                return [{ ...entity, enrollments: [enrollmentFromProgram] }];
+            else return [];
         });
-        return filteredEntities;
     }
 
     private getEntitiesWithoutClosure(
@@ -108,6 +158,7 @@ export class ClosePatientsUseCase {
 
             const enrollmentFromProgram = enrollments.find(enrollment => enrollment.program === programId);
             if (
+                //if enrollment exist, if enrollment STILLS ACTIVE, if there is not event with programStage (closureId) (deleted ones not count)
                 enrollmentFromProgram &&
                 enrollmentFromProgram.status === "ACTIVE" &&
                 !enrollmentFromProgram.events?.some(


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/3e0hfpu

### :memo: Implementation

- Include in the report patients with enrollment completed but no closure event
- Add save report from affected enrollments and events. If some error occurs it will be added to the report also.